### PR TITLE
Use C++17 also on windows

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -11,7 +11,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -11,7 +11,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -7,7 +7,7 @@ c_compiler:
 c_compiler_version:
 - '12'
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -7,7 +7,7 @@ c_compiler:
 c_compiler_version:
 - '12'
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/osx_arm64_openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_openssl1.1.1.yaml
@@ -7,7 +7,7 @@ c_compiler:
 c_compiler_version:
 - '12'
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/osx_arm64_openssl3.yaml
+++ b/.ci_support/osx_arm64_openssl3.yaml
@@ -7,7 +7,7 @@ c_compiler:
 c_compiler_version:
 - '12'
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/win_64_openssl1.1.1.yaml
+++ b/.ci_support/win_64_openssl1.1.1.yaml
@@ -3,7 +3,7 @@ abseil_cpp:
 c_compiler:
 - vs2017
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/.ci_support/win_64_openssl3.yaml
+++ b/.ci_support/win_64_openssl3.yaml
@@ -3,7 +3,7 @@ abseil_cpp:
 c_compiler:
 - vs2017
 channel_sources:
-- conda-forge
+- conda-forge/label/abseil_dev,conda-forge
 channel_targets:
 - conda-forge grpc_dev
 cxx_compiler:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,13 +7,14 @@
 
 set CFLAGS=
 set CXXFLAGS=
+set ABSL_CONSUME_DLL=1
 
 mkdir build-cpp
 cd build-cpp
 
 cmake ..  ^
     -GNinja ^
-    -DCMAKE_CXX_STANDARD=17 ^
+    -DCMAKE_CXX_STANDARD=11 ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,6 +13,7 @@ cd build-cpp
 
 cmake ..  ^
     -GNinja ^
+    -DCMAKE_CXX_STANDARD=17 ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,3 +5,6 @@ cxx_compiler_version:  # [linux]
 
 channel_targets:
   - conda-forge grpc_dev
+
+channel_sources:
+  - conda-forge/label/abseil_dev,conda-forge


### PR DESCRIPTION
Currently needs builds from `abseil_dev`. All this is liable to break the arrow CI, hence pushing into a dev channel here as well.