### PR TITLE
Re-enable pkg-config tests on windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,12 +97,11 @@ outputs:
         {% endfor %}
 
         # pkg-config (no metadata for vendored libs)
-        # should work on windows in principle, but our openssl builds don't have a .pc file
         {% for each_lib in core_libs %}
-        - pkg-config --print-errors --exact-version "{{ core_version }}" {{ each_lib }}  # [unix]
+        - pkg-config --print-errors --exact-version "{{ core_version }}" {{ each_lib }}
         {% endfor %}
         {% for each_lib in core_cpp_libs %}
-        - pkg-config --print-errors --exact-version "{{ version }}" {{ each_lib }}       # [unix]
+        - pkg-config --print-errors --exact-version "{{ version }}" {{ each_lib }}
         {% endfor %}
 
         # final CMake test to compile examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ source:
     - patches/0004-force-protoc-executable.patch
     - patches/0005-patch-tests-to-use-passed-CXX_STANDARD.patch
     - patches/0006-switch-to-C-17-for-grpcio.patch
+    - patches/0007-fix-pkgconfig-for-abseil_dll.patch  # [win]
 
 build:
   number: 8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,7 +106,6 @@ outputs:
         {% endfor %}
 
         # final CMake test to compile examples
-        # partially disabled on unix until libprotobuf-feedstock#127 & 128 are merged
         - ./test_grpc.sh   # [unix]
         - ./test_grpc.bat  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     - patches/0006-switch-to-C-17-for-grpcio.patch
 
 build:
-  number: 7
+  number: 8
 
 outputs:
   - name: grpc-cpp

--- a/recipe/patches/0001-windows-ssl-lib-names.patch
+++ b/recipe/patches/0001-windows-ssl-lib-names.patch
@@ -1,7 +1,7 @@
 From 1d5e1e33a467efb8f4f8c77389538eea6cd06265 Mon Sep 17 00:00:00 2001
 From: Jonathan Helmus <jjhelmus@gmail.com>
 Date: Mon, 17 Feb 2020 15:45:06 -0600
-Subject: [PATCH 1/6] windows ssl lib names
+Subject: [PATCH 1/7] windows ssl lib names
 
 Co-Authored-By: Julien Schueller <schueller@phimeca.com>
 Co-Authored-By: Nicholas Bollweg <nick.bollweg@gmail.com>

--- a/recipe/patches/0002-fix-win-setup-cmds.patch
+++ b/recipe/patches/0002-fix-win-setup-cmds.patch
@@ -1,7 +1,7 @@
 From 52f116a169ebfce67281817b4418801804f76e21 Mon Sep 17 00:00:00 2001
 From: Mike Sarahan <msarahan@gmail.com>
 Date: Tue, 18 Feb 2020 13:53:05 -0600
-Subject: [PATCH 2/6] fix win setup cmds
+Subject: [PATCH 2/7] fix win setup cmds
 
 Co-Authored-By: Julien Schueller <schueller@phimeca.com>
 Co-Authored-By: Nicholas Bollweg <nick.bollweg@gmail.com>

--- a/recipe/patches/0003-Link-against-grpc.patch
+++ b/recipe/patches/0003-Link-against-grpc.patch
@@ -1,7 +1,7 @@
 From 9b097e68e04f356390674324a1c34111f001c48e Mon Sep 17 00:00:00 2001
 From: Marius van Niekerk <marius.v.niekerk@gmail.com>
 Date: Mon, 13 Jun 2022 17:13:07 -0400
-Subject: [PATCH 3/6] Link against grpc
+Subject: [PATCH 3/7] Link against grpc
 
 ---
  setup.py | 11 +++++++++++

--- a/recipe/patches/0004-force-protoc-executable.patch
+++ b/recipe/patches/0004-force-protoc-executable.patch
@@ -1,7 +1,7 @@
 From 4b8003046aa98d7869af723fe4b71f63e0de1cd4 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Fri, 11 Sep 2020 14:20:04 +0200
-Subject: [PATCH 4/6] force protoc executable
+Subject: [PATCH 4/7] force protoc executable
 
 ---
  cmake/protobuf.cmake | 17 ++---------------

--- a/recipe/patches/0005-patch-tests-to-use-passed-CXX_STANDARD.patch
+++ b/recipe/patches/0005-patch-tests-to-use-passed-CXX_STANDARD.patch
@@ -1,7 +1,7 @@
 From 381024f44edfa5cb0cd31d32af1e1f91dea207c8 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 31 Aug 2022 18:52:58 +0200
-Subject: [PATCH 5/6] patch tests to use passed CXX_STANDARD
+Subject: [PATCH 5/7] patch tests to use passed CXX_STANDARD
 
 ---
  examples/cpp/cmake/common.cmake | 4 +++-

--- a/recipe/patches/0006-switch-to-C-17-for-grpcio.patch
+++ b/recipe/patches/0006-switch-to-C-17-for-grpcio.patch
@@ -1,7 +1,7 @@
 From 85e08fa143a6af460eb78d44399b28bd3b4f7083 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 3 Sep 2022 19:23:15 +0200
-Subject: [PATCH 6/6] switch to C++17 for grpcio
+Subject: [PATCH 6/7] switch to C++17 for grpcio
 
 ---
  setup.py | 6 +++---

--- a/recipe/patches/0007-fix-pkgconfig-for-abseil_dll.patch
+++ b/recipe/patches/0007-fix-pkgconfig-for-abseil_dll.patch
@@ -1,0 +1,61 @@
+From e34a86fb8da817b9ba1e2a82153640b057bb6c4f Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Thu, 8 Sep 2022 18:40:22 +0200
+Subject: [PATCH 7/7] fix pkgconfig for abseil_dll
+
+---
+ CMakeLists.txt | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2bfbcd4c6b..b9fbaa9b3c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17460,7 +17460,7 @@ generate_pkgconfig(
+   "gpr"
+   "gRPC platform support library"
+   "${gRPC_CORE_VERSION}"
+-  "absl_base absl_cord absl_core_headers absl_memory absl_optional absl_random_random absl_status absl_str_format absl_strings absl_synchronization absl_time"
++  "abseil_dll"
+   "-lgpr"
+   ""
+   "gpr.pc")
+@@ -17470,7 +17470,7 @@ generate_pkgconfig(
+   "gRPC"
+   "high performance general RPC framework"
+   "${gRPC_CORE_VERSION}"
+-  "gpr openssl absl_base absl_bind_front absl_cord absl_core_headers absl_flat_hash_map absl_hash absl_inlined_vector absl_memory absl_optional absl_random_random absl_status absl_statusor absl_str_format absl_strings absl_synchronization absl_time absl_utility absl_variant"
++  "gpr openssl abseil_dll"
+   "-lgrpc -laddress_sorting -lre2 -lupb -lcares -lz"
+   ""
+   "grpc.pc")
+@@ -17480,7 +17480,7 @@ generate_pkgconfig(
+   "gRPC unsecure"
+   "high performance general RPC framework without SSL"
+   "${gRPC_CORE_VERSION}"
+-  "gpr absl_base absl_bind_front absl_cord absl_core_headers absl_flat_hash_map absl_hash absl_inlined_vector absl_memory absl_optional absl_random_random absl_status absl_statusor absl_str_format absl_strings absl_synchronization absl_time absl_utility absl_variant"
++  "gpr abseil_dll"
+   "-lgrpc_unsecure"
+   ""
+   "grpc_unsecure.pc")
+@@ -17490,7 +17490,7 @@ generate_pkgconfig(
+   "gRPC++"
+   "C++ wrapper for gRPC"
+   "${gRPC_CPP_VERSION}"
+-  "grpc absl_base absl_bind_front absl_cord absl_core_headers absl_flat_hash_map absl_hash absl_inlined_vector absl_memory absl_optional absl_random_random absl_status absl_statusor absl_str_format absl_strings absl_synchronization absl_time absl_utility absl_variant"
++  "grpc abseil_dll"
+   "-lgrpc++"
+   ""
+   "grpc++.pc")
+@@ -17500,7 +17500,7 @@ generate_pkgconfig(
+   "gRPC++ unsecure"
+   "C++ wrapper for gRPC without SSL"
+   "${gRPC_CPP_VERSION}"
+-  "grpc_unsecure absl_base absl_bind_front absl_cord absl_core_headers absl_flat_hash_map absl_hash absl_inlined_vector absl_memory absl_optional absl_random_random absl_status absl_statusor absl_str_format absl_strings absl_synchronization absl_time absl_utility absl_variant"
++  "grpc_unsecure abseil_dll"
+   "-lgrpc++_unsecure"
+   ""
+   "grpc++_unsecure.pc")
+-- 
+2.37.0.windows.1
+

--- a/recipe/test_grpc.sh
+++ b/recipe/test_grpc.sh
@@ -8,8 +8,6 @@ if [[ "${build_platform}" == "${target_platform}" ]]; then
   test -f hello.grpc.pb.cc
 fi
 
-# disabled on unix until libprotobuf-feedstock#127 & 128 are merged
-if [[ 0 == 1 ]]; then
 # taken from cd examples/cpp/helloworld
 cd examples/cpp/helloworld
 
@@ -24,4 +22,3 @@ cmake -G "Ninja" \
     ..
 
 cmake --build .
-fi

--- a/recipe/test_grpc.sh
+++ b/recipe/test_grpc.sh
@@ -16,9 +16,8 @@ mkdir build-cpp
 cd build-cpp
 
 cmake -G "Ninja" \
+    ${CMAKE_ARGS} \
     -DCMAKE_CXX_STANDARD=17 \
-    -DCMAKE_PREFIX_PATH="$PREFIX" \
-    -DCMAKE_MODULE_PATH="$PREFIX/lib/cmake" \
     ..
 
 cmake --build .


### PR DESCRIPTION
I tried adding CMake metadata in conda-forge/libprotobuf-feedstock#128 (to re-enable the CMake tests on unix), but this caused some fall-out. However, CMake has its own custom `FindProtobuf` [function](https://github.com/Kitware/CMake/blob/v3.24.1/Modules/FindProtobuf.cmake) that takes precedence over the packaged CMake metadata; perhaps it's still possible to nudge it to find our `protobuf-config`-less protobuf)