### PR TITLE
re-enable pkg-config tests on windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,12 +103,11 @@ outputs:
         {% endfor %}
 
         # pkg-config (no metadata for vendored libs)
-        # should work on windows in principle, but our openssl builds don't have a .pc file
         {% for each_lib in core_libs %}
-        - pkg-config --print-errors --exact-version "{{ core_version }}" {{ each_lib }}  # [unix]
+        - pkg-config --print-errors --exact-version "{{ core_version }}" {{ each_lib }}
         {% endfor %}
         {% for each_lib in core_cpp_libs %}
-        - pkg-config --print-errors --exact-version "{{ version }}" {{ each_lib }}       # [unix]
+        - pkg-config --print-errors --exact-version "{{ version }}" {{ each_lib }}
         {% endfor %}
 
         # final CMake test to compile examples


### PR DESCRIPTION
Try #242 again for main now that https://github.com/conda-forge/abseil-cpp-feedstock/pull/51 & https://github.com/conda-forge/openssl-feedstock/pull/106 are in place

Closes #242