### PR TITLE
rebuild against looser abseil

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0006-fix-abseil-setup.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: libgrpc


### PR DESCRIPTION
Trying to fix errors now that we have abseil 20230125.2, which conflicts with previous run-exports of ".0" despite https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/453