### PR TITLE
patch in dll-visibility for a class needed by arrow

### DIFF
--- a/recipe/cmake_test/CMakeLists.txt
+++ b/recipe/cmake_test/CMakeLists.txt
@@ -1,0 +1,6 @@
+project(cf_dummy LANGUAGES C CXX)
+cmake_minimum_required(VERSION 3.12)
+find_package(gRPC REQUIRED)
+
+add_executable(grpc_example ${CMAKE_CURRENT_BINARY_DIR}/grpc_example.cc)
+target_link_libraries(grpc_example PRIVATE gRPC::grpc++)

--- a/recipe/cmake_test/grpc_example.cc
+++ b/recipe/cmake_test/grpc_example.cc
@@ -1,0 +1,18 @@
+// inspired by usage in arrow, see
+// https://github.com/apache/arrow/blob/apache-arrow-12.0.0/cpp/src/arrow/flight/transport/grpc/grpc_client.cc#L620-L622
+
+#include <memory>
+
+#include <grpcpp/security/tls_credentials_options.h>
+
+constexpr char kDummyRootCert[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "[snip]\n"
+    "-----END CERTIFICATE-----\n";
+
+int main()
+{
+    auto certificate_provider = std::make_shared<::grpc::experimental::StaticDataCertificateProvider>(
+          kDummyRootCert);
+    return 0;
+}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,13 @@ source:
     - patches/0008-add-GPR-GRPC-GRPCXX-UBP-_DLL-mechanism-for-missing-s.patch  # [win]
     - patches/0009-fix-support_enabled-for-windows.patch                       # [win]
     - patches/0010-Fix-data-with-thread-storage-duration-may-not-have-d.patch  # [win]
+    - patches/0011-put-some-grpc-experimental-classes-needed-by-arrow-i.patch  # [win]
+    - patches/0012-link-grpc-_unsecure-to-grpc.patch                           # [win]
+    # unbreak CMake integration
+    - patches/0013-don-t-use-find_dependency-for-protobuf.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libgrpc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,6 +84,7 @@ outputs:
         # only required for pkg-config test (which wants to find zlib.pc)
         - zlib  # [win]
       files:
+        - cmake_test/
         - hello.proto
         - test_grpc.sh
         - test_grpc.bat
@@ -116,9 +117,15 @@ outputs:
         - pkg-config --print-errors --exact-version "{{ version }}" {{ each_lib }}
         {% endfor %}
 
-        # final CMake test to compile examples
+        # CMake test: compile upstream example
         - ./test_grpc.sh   # [unix]
         - ./test_grpc.bat  # [win]
+
+        # test availability of symbol needed by arrow (esp. on windows)
+        - cd cmake_test
+        - cmake -GNinja -DCMAKE_CXX_STANDARD=17 $CMAKE_ARGS .   # [unix]
+        - cmake -GNinja -DCMAKE_CXX_STANDARD=17 %CMAKE_ARGS% .  # [win]
+        - cmake --build .
 
   - name: grpcio
     script: build-grpcio.sh  # [not win]

--- a/recipe/patches/0001-windows-ssl-lib-names.patch
+++ b/recipe/patches/0001-windows-ssl-lib-names.patch
@@ -1,7 +1,7 @@
 From 59ed62d5a90cc65599854f52f92918222e23ff8c Mon Sep 17 00:00:00 2001
 From: Jonathan Helmus <jjhelmus@gmail.com>
 Date: Mon, 17 Feb 2020 15:45:06 -0600
-Subject: [PATCH 01/10] windows ssl lib names
+Subject: [PATCH 01/13] windows ssl lib names
 
 Co-Authored-By: Julien Schueller <schueller@phimeca.com>
 Co-Authored-By: Nicholas Bollweg <nick.bollweg@gmail.com>

--- a/recipe/patches/0002-fix-win-setup-cmds.patch
+++ b/recipe/patches/0002-fix-win-setup-cmds.patch
@@ -1,7 +1,7 @@
 From 8762068e71fd84e91c1fc4b7c47e79ab80cd027d Mon Sep 17 00:00:00 2001
 From: Mike Sarahan <msarahan@gmail.com>
 Date: Tue, 18 Feb 2020 13:53:05 -0600
-Subject: [PATCH 02/10] fix win setup cmds
+Subject: [PATCH 02/13] fix win setup cmds
 
 Co-Authored-By: Julien Schueller <schueller@phimeca.com>
 Co-Authored-By: Nicholas Bollweg <nick.bollweg@gmail.com>

--- a/recipe/patches/0003-Link-against-grpc.patch
+++ b/recipe/patches/0003-Link-against-grpc.patch
@@ -1,7 +1,7 @@
 From 7ec86cc8780ad9b769c1b90ec0b85985e7ef3530 Mon Sep 17 00:00:00 2001
 From: Marius van Niekerk <marius.v.niekerk@gmail.com>
 Date: Mon, 13 Jun 2022 17:13:07 -0400
-Subject: [PATCH 03/10] Link against grpc
+Subject: [PATCH 03/13] Link against grpc
 
 ---
  setup.py | 10 ++++++++++

--- a/recipe/patches/0004-force-protoc-executable.patch
+++ b/recipe/patches/0004-force-protoc-executable.patch
@@ -1,7 +1,7 @@
 From f1f45c4abb00ef7556371cc9bb3fcba56eea4f69 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Fri, 11 Sep 2020 14:20:04 +0200
-Subject: [PATCH 04/10] force protoc executable
+Subject: [PATCH 04/13] force protoc executable
 
 ---
  cmake/protobuf.cmake | 17 ++---------------

--- a/recipe/patches/0005-switch-to-C-17-for-grpcio.patch
+++ b/recipe/patches/0005-switch-to-C-17-for-grpcio.patch
@@ -1,7 +1,7 @@
 From 21fe72b1d0ce0536b1612ad994b345e764a27fec Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 3 Sep 2022 19:23:15 +0200
-Subject: [PATCH 05/10] switch to C++17 for grpcio
+Subject: [PATCH 05/13] switch to C++17 for grpcio
 
 ---
  setup.py | 7 ++++---

--- a/recipe/patches/0006-fix-abseil-setup.patch
+++ b/recipe/patches/0006-fix-abseil-setup.patch
@@ -1,7 +1,7 @@
 From 4a28dd3764314482a05d5b57103f8b74cf4ab06c Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 4 Sep 2022 14:34:52 +0200
-Subject: [PATCH 06/10] fix abseil setup
+Subject: [PATCH 06/13] fix abseil setup
 
 ---
  setup.py | 14 +++++++++++---

--- a/recipe/patches/0007-mark-linkage-of-c-ares-re2-zlib-as-private.patch
+++ b/recipe/patches/0007-mark-linkage-of-c-ares-re2-zlib-as-private.patch
@@ -1,7 +1,7 @@
 From e9acaf62bba7d87bbd05c59083d382e3cf777d48 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 23 Aug 2022 11:45:20 +0200
-Subject: [PATCH 07/10] mark linkage of c-ares/re2/zlib as private
+Subject: [PATCH 07/13] mark linkage of c-ares/re2/zlib as private
 
 See also: https://github.com/grpc/grpc/issues/30838
 

--- a/recipe/patches/0008-add-GPR-GRPC-GRPCXX-UBP-_DLL-mechanism-for-missing-s.patch
+++ b/recipe/patches/0008-add-GPR-GRPC-GRPCXX-UBP-_DLL-mechanism-for-missing-s.patch
@@ -1,7 +1,7 @@
 From e16c8fc88094116516f0f21ec19e4d8f94e81f36 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sat, 22 Oct 2022 01:21:56 -0500
-Subject: [PATCH 08/10] add {GPR,GRPC,GRPCXX,UBP}_DLL mechanism for missing
+Subject: [PATCH 08/13] add {GPR,GRPC,GRPCXX,UBP}_DLL mechanism for missing
  symbols on windows
 
 Co-Authored-By: "H. Vetinari" <h.vetinari@gmx.com>

--- a/recipe/patches/0009-fix-support_enabled-for-windows.patch
+++ b/recipe/patches/0009-fix-support_enabled-for-windows.patch
@@ -1,7 +1,7 @@
 From 22f6844709000b6a4a37312bd130cb23b7d3cdd3 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sat, 22 Oct 2022 02:21:08 -0500
-Subject: [PATCH 09/10] fix support_enabled for windows
+Subject: [PATCH 09/13] fix support_enabled for windows
 
 ---
  src/core/lib/gprpp/fork.cc | 12 ++++++++++++

--- a/recipe/patches/0010-Fix-data-with-thread-storage-duration-may-not-have-d.patch
+++ b/recipe/patches/0010-Fix-data-with-thread-storage-duration-may-not-have-d.patch
@@ -1,7 +1,7 @@
 From 3a56d02efb3359ef40a1fc982341fd2aec095b91 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Mon, 8 May 2023 11:31:09 +1100
-Subject: [PATCH 10/10] Fix `data with thread storage duration may not have dll
+Subject: [PATCH 10/13] Fix `data with thread storage duration may not have dll
  interface`
 
 Windows needs a workaround.

--- a/recipe/patches/0011-put-some-grpc-experimental-classes-needed-by-arrow-i.patch
+++ b/recipe/patches/0011-put-some-grpc-experimental-classes-needed-by-arrow-i.patch
@@ -1,0 +1,68 @@
+From 47cc61d292a53346d71fdbc2b9a2a918a6888eed Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Fri, 9 Jun 2023 17:03:08 +1100
+Subject: [PATCH 11/13] put some grpc::experimental classes needed by arrow in
+ DLL
+
+also provide implementation for destructor of CertificateProviderInterface;
+I keep coming back to https://stackoverflow.com/a/57504289/2965879...
+---
+ include/grpcpp/security/tls_certificate_provider.h | 10 +++++-----
+ src/cpp/common/tls_certificate_provider.cc         |  2 ++
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/include/grpcpp/security/tls_certificate_provider.h b/include/grpcpp/security/tls_certificate_provider.h
+index ce9df5aa9c..44264b29c6 100644
+--- a/include/grpcpp/security/tls_certificate_provider.h
++++ b/include/grpcpp/security/tls_certificate_provider.h
+@@ -32,16 +32,16 @@ namespace experimental {
+ // Interface for a class that handles the process to fetch credential data.
+ // Implementations should be a wrapper class of an internal provider
+ // implementation.
+-class CertificateProviderInterface {
++class GRPCXX_DLL CertificateProviderInterface {
+  public:
+-  virtual ~CertificateProviderInterface() = default;
++  virtual ~CertificateProviderInterface();
+   virtual grpc_tls_certificate_provider* c_provider() = 0;
+ };
+ 
+ // A struct that stores the credential data presented to the peer in handshake
+ // to show local identity. The private_key and certificate_chain should always
+ // match.
+-struct IdentityKeyCertPair {
++struct GRPCXX_DLL IdentityKeyCertPair {
+   std::string private_key;
+   std::string certificate_chain;
+ };
+@@ -49,7 +49,7 @@ struct IdentityKeyCertPair {
+ // A basic CertificateProviderInterface implementation that will load credential
+ // data from static string during initialization. This provider will always
+ // return the same cert data for all cert names, and reloading is not supported.
+-class StaticDataCertificateProvider : public CertificateProviderInterface {
++class GRPCXX_DLL StaticDataCertificateProvider : public CertificateProviderInterface {
+  public:
+   StaticDataCertificateProvider(
+       const std::string& root_certificate,
+@@ -84,7 +84,7 @@ class StaticDataCertificateProvider : public CertificateProviderInterface {
+ //   then renaming the new directory to the original name of the old directory.
+ //   2)  using a symlink for the directory. When need to change, put new
+ //   credential data in a new directory, and change symlink.
+-class FileWatcherCertificateProvider final
++class GRPCXX_DLL FileWatcherCertificateProvider final
+     : public CertificateProviderInterface {
+  public:
+   // Constructor to get credential updates from root and identity file paths.
+diff --git a/src/cpp/common/tls_certificate_provider.cc b/src/cpp/common/tls_certificate_provider.cc
+index c51c0ea589..5ee9b50e16 100644
+--- a/src/cpp/common/tls_certificate_provider.cc
++++ b/src/cpp/common/tls_certificate_provider.cc
+@@ -24,6 +24,8 @@
+ namespace grpc {
+ namespace experimental {
+ 
++CertificateProviderInterface::~CertificateProviderInterface() {};
++
+ StaticDataCertificateProvider::StaticDataCertificateProvider(
+     const std::string& root_certificate,
+     const std::vector<IdentityKeyCertPair>& identity_key_cert_pairs) {

--- a/recipe/patches/0012-link-grpc-_unsecure-to-grpc.patch
+++ b/recipe/patches/0012-link-grpc-_unsecure-to-grpc.patch
@@ -1,0 +1,22 @@
+From 0ad84f5a4cd29f576d9ebf8d83bd45776ec63342 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Fri, 9 Jun 2023 20:11:22 +1100
+Subject: [PATCH 12/13] link grpc++_unsecure to grpc++
+
+which is where CertificateProviderInterface etc. live
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 069a827d5d..2f32039c2b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4033,6 +4033,7 @@ target_link_libraries(grpc++_unsecure
+   ${_gRPC_ZLIB_LIBRARIES}
+   ${_gRPC_ALLTARGETS_LIBRARIES}
+   grpc_unsecure
++  grpc++
+ )
+ 
+ foreach(_hdr

--- a/recipe/patches/0013-don-t-use-find_dependency-for-protobuf.patch
+++ b/recipe/patches/0013-don-t-use-find_dependency-for-protobuf.patch
@@ -1,0 +1,21 @@
+From d87627af46a4b2d425420c7dcea2d74a1a38ac1e Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Fri, 9 Jun 2023 22:16:09 +1100
+Subject: [PATCH 13/13] don't use find_dependency for protobuf
+
+---
+ cmake/protobuf.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/protobuf.cmake b/cmake/protobuf.cmake
+index 96213e7523..28f3498b78 100644
+--- a/cmake/protobuf.cmake
++++ b/cmake/protobuf.cmake
+@@ -73,6 +73,6 @@ elseif(gRPC_PROTOBUF_PROVIDER STREQUAL "package")
+     endif()
+     set(_gRPC_PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
+     set(_gRPC_PROTOBUF_PROTOC ${Protobuf_PROTOC_EXECUTABLE})
+-    set(_gRPC_FIND_PROTOBUF "find_dependency(Protobuf CONFIG)")
++    set(_gRPC_FIND_PROTOBUF "find_package(Protobuf CONFIG)")
+   endif()
+ endif()


### PR DESCRIPTION
With the switch to shared builds on windows, arrow doesn't compile anymore, see https://github.com/conda-forge/arrow-cpp-feedstock/pull/1082.

