### PR TITLE
grpc 1.57.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.57.0" %}
+{% set version = "1.57.1" %}
 
 # core package & vendored libs use different version scheme than CPP libs, see
 # https://github.com/grpc/grpc/blob/v1.48.1/CMakeLists.txt#L28-L32
@@ -19,7 +19,7 @@ package:
 
 source:
   url: https://github.com/grpc/grpc/archive/v{{ version.replace(".pre", "-pre") }}.tar.gz
-  sha256: 8393767af531b2d0549a4c26cf8ba1f665b16c16fb6c9238a7755e45444881dd
+  sha256: 0762f809b9de845e6a7c809cabccad6aa4143479fd43b396611fe5a086c0aeeb
   patches:
     - patches/0001-windows-ssl-lib-names.patch         # [win]
     - patches/0002-fix-win-setup-cmds.patch            # [win]
@@ -41,7 +41,7 @@ source:
     - patches/0013-don-t-use-find_dependency-for-protobuf.patch
 
 build:
-  number: 3
+  number: 0
 
 outputs:
   - name: libgrpc


### PR DESCRIPTION
Upstream released new versions for 5 branches, I guess that's indicative of how serious it is (even though only the latest release is affected by a CVE)